### PR TITLE
Update dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: scala
 scala:
-   - 2.10.5
-   - 2.11.7
+   - 2.11.8
+jdk:
+  - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   version := "0.1.6",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.6", "2.11.8")
+  crossScalaVersions := Seq("2.11.8")
 )
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-http" % "6.35.0",
-    "org.scalacheck" %% "scalacheck" % "1.13.1" % "test",
+    "com.twitter" %% "finagle-http" % "6.37.0",
+    "org.scalacheck" %% "scalacheck" % "1.13.2" % "test",
     "org.scalatest" %% "scalatest" % "3.0.0" % "test"
   )
 )

--- a/src/main/scala/com/twitter/finagle/oauth2/ClientCredentialFetcher.scala
+++ b/src/main/scala/com/twitter/finagle/oauth2/ClientCredentialFetcher.scala
@@ -1,23 +1,30 @@
 package com.twitter.finagle.oauth2
 
-import org.apache.commons.codec.binary.Base64
+import java.util.Base64
 
 case class ClientCredential(clientId: String, clientSecret: String)
 
 trait ClientCredentialFetcher {
 
+  private[this] val base64Decoder = Base64.getMimeDecoder
+  private[this] def tryDecode(encoded: String): Option[String] = {
+    try Some(new String(base64Decoder.decode(encoded), "UTF-8"))
+    catch {
+      case iae: IllegalArgumentException => None
+    }
+  }
+  private[this] val basicAuthPattern = "(?i)basic.*".r.pattern
+  private[this] def isBasicAuthHeader(header: String): Boolean =
+    basicAuthPattern.matcher(header).matches
+
   def fetch(request: AuthorizationRequest): Option[ClientCredential] = {
     request.header("Authorization") match {
-      case Some(authorization) if authorization.length > 5 =>
-        val decoded = new String(Base64.decodeBase64(authorization.substring(6).getBytes), "UTF-8")
-        if (decoded.indexOf(':') > 0) {
-          decoded.split(":", 2) match {
-            case Array(clientId, clientSecret) => Option(ClientCredential(clientId, clientSecret))
-            case Array(clientId) => Option(ClientCredential(clientId, ""))
-            case _ => None
-          }
-        } else {
-          None
+      case Some(authHeader) if isBasicAuthHeader(authHeader) =>
+        val credentials = authHeader.substring(6)
+        tryDecode(credentials).map(_.split(":", 2)) flatMap {
+            case Array(clientId, clientSecret) => Some(ClientCredential(clientId, clientSecret))
+            case Array(clientId) if clientId.nonEmpty => Some(ClientCredential(clientId, ""))
+            case other => None
         }
       case _ => request.clientId.map { clientId =>
         ClientCredential(clientId, request.clientSecret.getOrElse(""))


### PR DESCRIPTION
- finagle: 6.33.0 -> 6.37.0
- scalacheck (for testing): 1.12.4 -> 1.13.2
- scalatest (for testing): 2.2.5 -> 3.0.0
- scala 2.11: 2.11.7 -> 2.11.8
- scala 2.10: 2.10.6 -> GONE! (see notes below)
- sbt: 0.13.8 -> 0.13.12

Notes:
- Upstream Finagle has dropped support for Scala 2.10, so I'm following
  suite here so I can update to the latest Finagle version
- Apache Commons Codec fell out of the transitive dependency set.
  Rather than pulling it in just to do Base64 decoding, I've ported the
  code in `ClientCredentialFetcher.scala` to use the Java 8 Base64
  class. I've also taken the liberty of moving the String parsing there
  to use a precompiled case-insensitive regex to identify basic auth
  headers, as this seems more robust than the previous length-based
  approach that was previously being used.
