### PR TITLE
Simplify error handling with scala.util.Try

### DIFF
--- a/src/main/scala/com/twitter/finagle/oauth2/ClientCredentialFetcher.scala
+++ b/src/main/scala/com/twitter/finagle/oauth2/ClientCredentialFetcher.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.oauth2
 
 import java.util.Base64
+import scala.util.Try
 
 case class ClientCredential(clientId: String, clientSecret: String)
 
@@ -8,10 +9,7 @@ trait ClientCredentialFetcher {
 
   private[this] val base64Decoder = Base64.getMimeDecoder
   private[this] def tryDecode(encoded: String): Option[String] = {
-    try Some(new String(base64Decoder.decode(encoded), "UTF-8"))
-    catch {
-      case iae: IllegalArgumentException => None
-    }
+    Try(new String(base64Decoder.decode(encoded), "UTF-8")).toOption
   }
   private[this] val basicAuthPattern = "(?i)basic.*".r.pattern
   private[this] def isBasicAuthHeader(header: String): Boolean =


### PR DESCRIPTION
### Problem:
If the code below throws a different exception, `None` is still returned. 
```scala
def test = {
  try Some("qq".toInt)
  catch { case iae: IllegalArgumentException => None }
}

test // returns None even though the exception was NumberFormatException
```

### Solution:
With this behavior, we can simplify the code by wrapping the computation with`Try` and invoking `toOption` on the result.