### PR TITLE
update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  version := "6.43.0",
+  version := "0.6.43",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  version := "0.4.0",
+  version := "0.4.1",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
@@ -8,8 +8,8 @@ lazy val buildSettings = Seq(
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-http" % "6.43.0",
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.13.5" % Test,
+    "org.scalatest" %% "scalatest" % "3.0.1" % Test
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  version := "0.4.1",
+  version := "6.43.0",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )


### PR DESCRIPTION
move finagle version to 6.43.0. as long as I'm doing this I updated
scalacheck and scalatest because sbt-updates told me to. Although
I don't use this lib it is dependency of finch. 6.43.0 is binarily incompatible
with 6.42.0. so this is step one in getting finch to 6.43.0 so we can start 
testing http2. 

I have arbitrarily chosen 0.4.1 as the version since this project doesn't have
snapshot versions.